### PR TITLE
NP-2454 Options field added in Endpoint struct

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -102,12 +102,12 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:db80629ec1cb6f46cf6c92f350131811fc773fc67b5f9d5b57a84c1a01183613"
+  digest = "1:b52a2fe8739f28a53bafe7e2a86d6b366b709608994948bfd36a51b0f4980f5c"
   name = "github.com/nalej/grpc-application-go"
   packages = ["."]
   pruneopts = ""
-  revision = "23d094052316a074143e6fc61c5436320c8e2fb0"
-  version = "v0.0.91"
+  revision = "594475e57999382181b2208ffe627defb60ff09d"
+  version = "v0.0.92"
 
 [[projects]]
   digest = "1:0a59039a032ea25d8febb1a3730cb55f5a0dc87af71748d885ab9a7752a1dcc2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-application-go"
-    version="=v0.0.91"
+    version="=v0.0.92"
 
 [[constraint]]
     name="github.com/nalej/grpc-application-manager-go"

--- a/internal/pkg/entities/parameters.go
+++ b/internal/pkg/entities/parameters.go
@@ -207,8 +207,9 @@ func copyEndPoint(endpoint *grpc_application_go.Endpoint) *grpc_application_go.E
 		return nil
 	}
 	return &grpc_application_go.Endpoint{
-		Type: endpoint.Type,
-		Path: endpoint.Path,
+		Type:    endpoint.Type,
+		Path:    endpoint.Path,
+		Options: endpoint.Options,
 	}
 }
 


### PR DESCRIPTION
#### What does this PR do?
- updates grpc-protos to include Options in endpoint struct.
- validates these options. 
1) allowed if and only if the endpoint type is WEB
2) two options are allowed for now (CLIENT_MAX_BODY_SIZE and HOST_HEADER_CONFIGURATION)
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2454](https://nalej.atlassian.net/browse/NP-2454)

#### Screenshots (if appropriate)

#### Questions