### PR TITLE
NP-2539 DEFAULT_STORAGE_SIZE setting implemented

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -230,12 +230,20 @@
   version = "v0.0.45"
 
 [[projects]]
-  digest = "1:387d19966af24e7d1fb4b36fcef08323c5ea25f9ab51f41c435a53e60e681f6c"
+  digest = "1:7e26a8f455c4e7978f049bd0c2e53f7f1195e15f66fe1ba9f11bd278105ef803"
   name = "github.com/nalej/grpc-organization-go"
   packages = ["."]
   pruneopts = ""
-  revision = "6ff98153a51ca6d8c47512c2456f9f3b5ae31f9d"
-  version = "v0.0.29"
+  revision = "db43aba4f994f9c1b4740ff1c6126c636d5f5dd0"
+  version = "v0.0.34"
+
+[[projects]]
+  digest = "1:e93099df7b2c493f8a4cb0ff1e0948b382348ab07850d72480a7ebe406ed8d09"
+  name = "github.com/nalej/grpc-organization-manager-go"
+  packages = ["."]
+  pruneopts = ""
+  revision = "acf8c70e3c900214881f7189b89128da5d5f1e9c"
+  version = "v0.0.3"
 
 [[projects]]
   digest = "1:04665058968000b594204bad78216f04d1b575f8fefe558a4eeecc75964ebf62"
@@ -567,6 +575,7 @@
     "github.com/nalej/grpc-device-go",
     "github.com/nalej/grpc-infrastructure-go",
     "github.com/nalej/grpc-organization-go",
+    "github.com/nalej/grpc-organization-manager-go",
     "github.com/nalej/grpc-unified-logging-go",
     "github.com/nalej/grpc-utils/pkg/conversions",
     "github.com/nalej/grpc-utils/pkg/test",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,7 +48,11 @@
 
 [[constraint]]
     name="github.com/nalej/grpc-organization-go"
-    version="=v0.0.29"
+    version="=v0.0.34"
+
+[[constraint]]
+    name="github.com/nalej/grpc-organization-manager-go"
+    version="=v0.0.3"
 
 [[constraint]]
     name="github.com/nalej/grpc-common-go"

--- a/cmd/application-manager/commands/run.go
+++ b/cmd/application-manager/commands/run.go
@@ -48,5 +48,7 @@ func init() {
 		"Queue system address (host:port)")
 	runCmd.PersistentFlags().StringVar(&config.UnifiedLoggingAddress, "unifiedLoggingAddress", "localhost:8323",
 		"Unified Logging Coordinator address (host:port)")
+	runCmd.PersistentFlags().StringVar(&config.OrgManagerAddress, "organizationManagerAddress", "localhost:8950",
+		"Organization Manager address (host:port)")
 	rootCmd.AddCommand(runCmd)
 }

--- a/components/application-manager/mngtcluster/application-manager.deployment.yaml
+++ b/components/application-manager/mngtcluster/application-manager.deployment.yaml
@@ -31,6 +31,7 @@ spec:
             - "run"
             - "--systemModelAddress=system-model.__NPH_NAMESPACE:8800"
             - "--conductorAddress=conductor.__NPH_NAMESPACE:5000"
+            - "--organizationManagerAddress=organization-manager.__NPH_NAMESPACE:5000"
             - "--queueAddress=broker.__NPH_NAMESPACE:6650"
             - "--unifiedLoggingAddress=unified-logging-coord.__NPH_NAMESPACE:8323"
           securityContext:

--- a/internal/pkg/entities/organization_settings.go
+++ b/internal/pkg/entities/organization_settings.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Nalej
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package entities
+
+import (
+	"github.com/nalej/application-manager/internal/pkg/server/common"
+	"github.com/nalej/grpc-organization-go"
+	orgMng "github.com/nalej/grpc-organization-manager-go"
+	"github.com/rs/zerolog/log"
+	"strconv"
+)
+
+// OrganizationSettings contains all settings that can be applied in descriptors and instances
+// For now -> DEFAULT_STORAGE_SIZE
+type OrganizationSettings struct {
+	StoreSize int64
+}
+
+// NewOrganizationSettings generates a OrganizationSetting for a received organization
+func NewOrganizationSettings(organizationID string, client orgMng.OrganizationsClient) *OrganizationSettings {
+	log.Debug().Str("organizationId", organizationID).Msg("creating a new OrganizationSettings")
+
+	if client == nil {
+		return nil
+	}
+
+	defaultStore := int64(0)
+
+	ctx, cancel := common.GetContext()
+	defer cancel()
+
+	setting, err := client.GetSetting(ctx, &grpc_organization_go.SettingKey{
+		OrganizationId: organizationID,
+		Key:            grpc_organization_go.AllowedSettingKey_DEFAULT_STORAGE_SIZE.String(),
+	})
+	if err != nil {
+		log.Warn().Str("error", err.Error()).Str("setting", grpc_organization_go.AllowedSettingKey_DEFAULT_STORAGE_SIZE.String()).
+			Msg("error getting setting")
+	}else{
+		defaultStore, err = strconv.ParseInt(setting.Value, 10, 64)
+		if err != nil {
+			log.Warn().Str("error", err.Error()).Str("value", setting.Value).Msg("error converting the value to int")
+		}
+	}
+
+	return &OrganizationSettings{defaultStore}
+}

--- a/internal/pkg/entities/parameters_test.go
+++ b/internal/pkg/entities/parameters_test.go
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("Parameter tests", func() {
 
 			descriptor := utils.CreateTestDescriptor()
 
-			parametrized := newParametrizedDescriptorFromDescriptor(descriptor)
+			parametrized := newParametrizedDescriptorFromDescriptor(descriptor, nil)
 			gomega.Expect(parametrized).NotTo(gomega.BeNil())
 
 			// update descriptor and parametrized to check they are not the same
@@ -73,7 +73,7 @@ var _ = ginkgo.Describe("Parameter tests", func() {
 			parameters := grpc_application_go.InstanceParameterList{
 				Parameters: []*grpc_application_go.InstanceParameter{{ParameterName: "replicas", Value: "10"}, {ParameterName: "env1", Value: "modified"}},
 			}
-			parametrized, err := CreateParametrizedDescriptor(descriptor, &parameters)
+			parametrized, err := CreateParametrizedDescriptor(descriptor, &parameters, nil)
 			gomega.Expect(parametrized).NotTo(gomega.BeNil())
 			gomega.Expect(err).To(gomega.Succeed())
 			gomega.Expect(parametrized.Groups[0].Specs.Replicas).Should(gomega.Equal(int32(10)))
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("Parameter tests", func() {
 			parameters := grpc_application_go.InstanceParameterList{
 				Parameters: []*grpc_application_go.InstanceParameter{{ParameterName: "replicas", Value: "replicas test"}},
 			}
-			_, err := CreateParametrizedDescriptor(descriptor, &parameters)
+			_, err := CreateParametrizedDescriptor(descriptor, &parameters, nil)
 			gomega.Expect(err).NotTo(gomega.Succeed())
 		})
 		ginkgo.It("should not be able to create parametrized Descriptor with invalid parameter", func() {
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("Parameter tests", func() {
 			parameters := grpc_application_go.InstanceParameterList{
 				Parameters: []*grpc_application_go.InstanceParameter{{ParameterName: "invalid_param", Value: "10"}},
 			}
-			_, err := CreateParametrizedDescriptor(descriptor, &parameters)
+			_, err := CreateParametrizedDescriptor(descriptor, &parameters, nil)
 			gomega.Expect(err).NotTo(gomega.Succeed())
 		})
 		ginkgo.It("must recognize the parameters as valid", func() {

--- a/internal/pkg/server/application/manager.go
+++ b/internal/pkg/server/application/manager.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"github.com/nalej/application-manager/internal/pkg/entities"
 	appnet "github.com/nalej/application-manager/internal/pkg/server/application-network"
-	"github.com/nalej/application-manager/internal/pkg/server/common"
 	"github.com/nalej/derrors"
 	"github.com/nalej/grpc-application-go"
 	"github.com/nalej/grpc-application-manager-go"

--- a/internal/pkg/server/application/manager.go
+++ b/internal/pkg/server/application/manager.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/nalej/application-manager/internal/pkg/entities"
 	appnet "github.com/nalej/application-manager/internal/pkg/server/application-network"
+	"github.com/nalej/application-manager/internal/pkg/server/common"
 	"github.com/nalej/derrors"
 	"github.com/nalej/grpc-application-go"
 	"github.com/nalej/grpc-application-manager-go"
@@ -30,6 +31,7 @@ import (
 	"github.com/nalej/grpc-device-go"
 	"github.com/nalej/grpc-infrastructure-go"
 	"github.com/nalej/grpc-organization-go"
+	"github.com/nalej/grpc-organization-manager-go"
 	"github.com/nalej/grpc-utils/pkg/conversions"
 	"github.com/nalej/nalej-bus/pkg/queue/application/ops"
 	"github.com/rs/zerolog/log"
@@ -46,6 +48,7 @@ const OutboundNotDefined = "Deploy outbound connection not defined"
 // Manager structure with the required clients for roles operations.
 type Manager struct {
 	appClient       grpc_application_go.ApplicationsClient
+	orgClient       grpc_organization_manager_go.OrganizationsClient
 	conductorClient grpc_conductor_go.ConductorClient
 	clusterClient   grpc_infrastructure_go.ClustersClient
 	deviceClient    grpc_device_go.DevicesClient
@@ -57,13 +60,14 @@ type Manager struct {
 // NewManager creates a Manager using a set of clients.
 func NewManager(
 	appClient grpc_application_go.ApplicationsClient,
+	orgClient grpc_organization_manager_go.OrganizationsClient,
 	conductorClient grpc_conductor_go.ConductorClient,
 	clusterClient grpc_infrastructure_go.ClustersClient,
 	deviceClient grpc_device_go.DevicesClient,
 	appNetClient grpc_application_network_go.ApplicationNetworkClient,
 	appOpsProducer *ops.ApplicationOpsProducer,
 	appNetManager appnet.Manager) Manager {
-	return Manager{appClient, conductorClient, clusterClient, deviceClient, appNetClient, appOpsProducer, appNetManager}
+	return Manager{appClient, orgClient, conductorClient, clusterClient, deviceClient, appNetClient, appOpsProducer, appNetManager}
 }
 
 // AddAppDescriptor adds a new application descriptor to a given organization.
@@ -289,8 +293,10 @@ func (m *Manager) Deploy(deployRequest *grpc_application_manager_go.DeployReques
 		return nil, conversions.ToGRPCError(dErr)
 	}
 
+	orgSettings := entities.NewOrganizationSettings(deployRequest.OrganizationId, m.orgClient)
+
 	// Create it parametrized descriptor
-	parametrizedDesc, err := entities.CreateParametrizedDescriptor(desc, deployRequest.Parameters)
+	parametrizedDesc, err := entities.CreateParametrizedDescriptor(desc, deployRequest.Parameters, orgSettings)
 	if err != nil {
 		log.Error().Err(err).Msgf("error creating  parametrized descriptor %s.", deployRequest.AppDescriptorId)
 		return nil, err

--- a/internal/pkg/server/config.go
+++ b/internal/pkg/server/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	ConductorAddress string
 	// SystemModelAddress with the host:port to connect to System Model
 	SystemModelAddress string
+	// OrgManagerAddress with the host:port to connect to Organization Manager
+	OrgManagerAddress string
 	// Address where the queue system can be reached
 	QueueAddress string
 	// UnifiedLoggingAddress with the host:port to connect to the Unified Logging Coordinator component.
@@ -42,6 +44,10 @@ func (conf *Config) Validate() derrors.Error {
 
 	if conf.SystemModelAddress == "" {
 		return derrors.NewInvalidArgumentError("systemModelAddress must be set")
+	}
+
+	if conf.OrgManagerAddress == "" {
+		return derrors.NewInvalidArgumentError("organizationManagerAddress must be set")
 	}
 
 	if conf.QueueAddress == "" {
@@ -59,6 +65,7 @@ func (conf *Config) Print() {
 	log.Info().Int("port", conf.Port).Msg("gRPC port")
 	log.Info().Str("URL", conf.ConductorAddress).Msg("Conductor")
 	log.Info().Str("URL", conf.SystemModelAddress).Msg("System Model")
+	log.Info().Str("URL", conf.OrgManagerAddress).Msg("Organization Manager")
 	log.Info().Str("URL", conf.QueueAddress).Msg("Queue address")
 	log.Info().Str("URL", conf.UnifiedLoggingAddress).Msg("Unified Logging Coordinator Service")
 


### PR DESCRIPTION
#### What does this PR do?
Get the DEFAULT_STORAGE_SIZE setting and uses its value when creating a new ParametrizedDescriptor if the descriptor hasn't the size field filled
I have created a new entity `OrganizationSettings` to go including all the settings that we need in application-manager
#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?
- Add DEFAULT_STORAGE_SIZE in nalej.OrganizationSettings table
- Add a descriptor (mysql-wordpress) without size
- Deploy it
- check size defined in the deployment

#### Any background context you want to provide?

#### What are the relevant tickets?

- [NP-2539](https://nalej.atlassian.net/browse/NP-2539)

#### Screenshots (if appropriate)

#### Questions
